### PR TITLE
Install missing dependency in "Compile Examples" workflow

### DIFF
--- a/.github/workflows/Compile Examples.yml
+++ b/.github/workflows/Compile Examples.yml
@@ -57,6 +57,7 @@ jobs:
             - name: Adafruit GFX Library
             - name: Adafruit ST7735 and ST7789 Library
             - name: Arduino_MCHPTouch
+            - name: BME68x Sensor library
             - name: TFT_eSPI
           sketch-paths: |
             # Ignoring Display/AnimatedGif compiling the rest of them


### PR DESCRIPTION
The "Compile Examples" [GitHub Actions workflow](https://docs.github.com/actions/using-workflows/about-workflows) must be [configured](https://github.com/arduino/compile-sketches#libraries) to install all dependencies of the example sketches.

Installation of the library's newly added dependency "**BME68x Sensor library**" is provided by this pull request, as requested at https://github.com/arduino-libraries/Arduino_MKRIoTCarrier/pull/55#issuecomment-1225916642.

The workflow run is still failing due to the absence of another library. I did not add that one because I was only requested to add "**BME68x Sensor library**", but I am happy to make additional workflow updates if needed.